### PR TITLE
feat: mobile audio endpoint for Pipecat

### DIFF
--- a/server/bot.py
+++ b/server/bot.py
@@ -1,9 +1,12 @@
 import argparse
 import asyncio
+import json
 import os
 import sys
 from contextlib import asynccontextmanager
-from typing import Dict
+from datetime import datetime
+from typing import Dict, Optional
+import inspect
 
 # Add local pipecat to Python path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "pipecat", "src"))
@@ -11,7 +14,15 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "pipecat", "src"))
 from kokoro_tts import KokoroTTSService
 import uvicorn
 from dotenv import load_dotenv
-from fastapi import BackgroundTasks, FastAPI
+from fastapi import (
+    BackgroundTasks,
+    FastAPI,
+    File,
+    Header,
+    HTTPException,
+    UploadFile,
+    Response,
+)
 from loguru import logger
 
 from pipecat.audio.turn.smart_turn.base_smart_turn import SmartTurnParams
@@ -38,6 +49,27 @@ load_dotenv(override=True)
 app = FastAPI()
 
 pcs_map: Dict[str, SmallWebRTCConnection] = {}
+
+# Token used to authorize mobile API requests
+API_TOKEN = os.getenv("MOBILE_API_TOKEN")
+
+
+def _log_event(function: str, message: str, method: str, error: str | None = None) -> None:
+    """Emit structured log events and derived human-readable line."""
+    record = {
+        "filename": __file__,
+        "timestamp": datetime.utcnow().isoformat(),
+        "classname": "MobileAPI",
+        "function": function,
+        "system_section": "api",
+        "line_num": inspect.currentframe().f_back.f_lineno,
+        "error": error,
+        "db_phase": "none",
+        "method": method,
+        "message": message,
+    }
+    logger.info(json.dumps(record))
+    logger.info("The 17 Commandments of Quality Code")
 
 ice_servers = [
     IceServer(
@@ -181,6 +213,33 @@ async def offer(request: dict, background_tasks: BackgroundTasks):
     pcs_map[answer["pc_id"]] = pipecat_connection
 
     return answer
+
+
+@app.post("/api/mobile")
+async def mobile_endpoint(
+    file: UploadFile = File(...),
+    authorization: Optional[str] = Header(default=None),
+):
+    """Accept raw audio and return synthesized audio for mobile clients."""
+    if API_TOKEN and authorization != f"Bearer {API_TOKEN}":
+        _log_event("mobile_endpoint", "unauthorized", "POST", error="unauthorized")
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+    audio_bytes = await file.read()
+    _log_event("mobile_endpoint", "received_audio", "POST")
+
+    stt = WhisperSTTServiceMLX(model=MLXModel.LARGE_V3_TURBO_Q4)
+    loop = asyncio.get_running_loop()
+    transcript = await loop.run_in_executor(None, stt.transcribe, audio_bytes)
+    _log_event("mobile_endpoint", "transcribed_audio", "POST")
+
+    response_text = f"You said: {transcript}"
+
+    tts = KittenTTSService()
+    audio_out = await loop.run_in_executor(None, tts.synthesize, response_text)
+    _log_event("mobile_endpoint", "generated_audio", "POST")
+
+    return Response(content=audio_out, media_type="audio/wav")
 
 
 @asynccontextmanager

--- a/server/test_mobile_endpoint.py
+++ b/server/test_mobile_endpoint.py
@@ -1,0 +1,119 @@
+import io
+import sys
+import types
+import wave
+from importlib import reload
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def _sample_wav_bytes():
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(16000)
+        wf.writeframes(b"\x00\x00" * 160)
+    return buf.getvalue()
+
+
+def _prepare_env(monkeypatch):
+    token = "secret-token"
+    monkeypatch.setenv("MOBILE_API_TOKEN", token)
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    kokoro = types.ModuleType("kokoro_tts")
+    kokoro.KokoroTTSService = object
+    sys.modules["kokoro_tts"] = kokoro
+    sys.modules["kittentts_service"] = types.ModuleType("kittentts_service")
+    sys.modules["kittentts_service"].KittenTTSService = object
+    cv2_mod = types.ModuleType("cv2")
+    cv2_mod.__spec__ = types.SimpleNamespace()
+    sys.modules["cv2"] = cv2_mod
+
+    def stub(name: str, attrs: dict | None = None):
+        parts = name.split(".")
+        parent = None
+        module_name = ""
+        for part in parts:
+            module_name = f"{module_name}.{part}" if module_name else part
+            mod = sys.modules.get(module_name)
+            if mod is None:
+                mod = types.ModuleType(module_name)
+                sys.modules[module_name] = mod
+                if parent:
+                    setattr(parent, part, mod)
+            parent = mod
+        if attrs:
+            for k, v in attrs.items():
+                setattr(parent, k, v)
+
+    stub("pipecat.audio.turn.smart_turn.base_smart_turn", {"SmartTurnParams": object})
+    stub("pipecat.audio.turn.smart_turn.local_smart_turn_v2", {"LocalSmartTurnAnalyzerV2": object})
+    stub("pipecat.audio.vad.silero", {"SileroVADAnalyzer": object})
+    stub("pipecat.audio.vad.vad_analyzer", {"VADParams": object})
+    stub("pipecat.pipeline.pipeline", {"Pipeline": object})
+    stub("pipecat.pipeline.runner", {"PipelineRunner": object})
+    stub("pipecat.pipeline.task", {"PipelineParams": object, "PipelineTask": object})
+    stub("pipecat.processors.aggregators.openai_llm_context", {"OpenAILLMContext": object})
+    stub("pipecat.services.openai.llm", {"OpenAILLMService": object})
+    stub("pipecat.transports.base_transport", {"TransportParams": object})
+    stub("pipecat.processors.frameworks.rtvi", {"RTVIConfig": object, "RTVIObserver": object, "RTVIProcessor": object})
+    stub("pipecat.transports.network.small_webrtc", {"SmallWebRTCTransport": object})
+    class _IceServer:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    stub(
+        "pipecat.transports.network.webrtc_connection",
+        {"IceServer": _IceServer, "SmallWebRTCConnection": object},
+    )
+    stub("pipecat.processors.aggregators.llm_response", {"LLMUserAggregatorParams": object})
+    class _MLXModel:
+        LARGE_V3_TURBO_Q4 = object()
+
+    stub(
+        "pipecat.services.whisper.stt",
+        {"WhisperSTTServiceMLX": object, "MLXModel": _MLXModel},
+    )
+    import server.bot as bot  # noqa
+    reload(bot)
+    return token, bot
+
+
+def test_mobile_endpoint_success(monkeypatch):
+    token, bot = _prepare_env(monkeypatch)
+
+    class FakeSTT:
+        def transcribe(self, audio_bytes):
+            return "hello"
+
+    class FakeTTS:
+        def synthesize(self, text):
+            return b"audio-bytes"
+
+    monkeypatch.setattr(bot, "WhisperSTTServiceMLX", lambda *a, **k: FakeSTT())
+    monkeypatch.setattr(bot, "KittenTTSService", lambda *a, **k: FakeTTS())
+
+    client = TestClient(bot.app)
+    audio = _sample_wav_bytes()
+    response = client.post(
+        "/api/mobile",
+        files={"file": ("sample.wav", audio, "audio/wav")},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 200
+    assert response.content == b"audio-bytes"
+
+
+def test_mobile_endpoint_unauthorized(monkeypatch):
+    token, bot = _prepare_env(monkeypatch)
+
+    client = TestClient(bot.app)
+    audio = _sample_wav_bytes()
+    response = client.post(
+        "/api/mobile",
+        files={"file": ("sample.wav", audio, "audio/wav")},
+    )
+    assert response.status_code == 401


### PR DESCRIPTION
## Summary
- add `/api/mobile` endpoint for raw audio requests with token auth and structured logs
- log events in canonical format and synthesize responses via STT and TTS
- test authorized and unauthorized mobile audio requests

## Testing
- `python -m py_compile server/bot.py server/test_mobile_endpoint.py`
- `pytest server/test_mobile_endpoint.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa13439bb0832b994d372ff2bd27b9