### PR TITLE
Add Android llama build script and Flutter bridge plugin

### DIFF
--- a/client_flutter/android/build.gradle
+++ b/client_flutter/android/build.gradle
@@ -1,0 +1,18 @@
+plugins {
+    id 'com.android.library'
+    id 'org.jetbrains.kotlin.android'
+}
+
+android {
+    compileSdkVersion 33
+    defaultConfig {
+        minSdkVersion 24
+        targetSdkVersion 33
+    }
+    sourceSets {
+        main.java.srcDirs += 'src/main/kotlin'
+    }
+}
+
+dependencies {
+}

--- a/client_flutter/android/settings.gradle
+++ b/client_flutter/android/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'llama_bridge'

--- a/client_flutter/android/src/main/AndroidManifest.xml
+++ b/client_flutter/android/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example.llamabridge">
+    <application android:label="llama_bridge" />
+</manifest>

--- a/client_flutter/android/src/main/kotlin/com/example/llamabridge/LlamaBridgePlugin.kt
+++ b/client_flutter/android/src/main/kotlin/com/example/llamabridge/LlamaBridgePlugin.kt
@@ -1,0 +1,109 @@
+package com.example.llamabridge
+
+import android.content.Context
+import android.os.SystemClock
+import androidx.annotation.Keep
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.EventChannel
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import java.io.File
+import java.io.FileOutputStream
+import java.net.URL
+import org.json.JSONObject
+
+class LlamaBridgePlugin: FlutterPlugin, MethodChannel.MethodCallHandler, EventChannel.StreamHandler {
+    private lateinit var methodChannel: MethodChannel
+    private lateinit var eventChannel: EventChannel
+    private var sink: EventChannel.EventSink? = null
+    private lateinit var context: Context
+
+    external fun init(modelPath: String): Boolean
+    external fun infer(prompt: String)
+
+    private fun log(function: String, message: String) {
+        val json = JSONObject()
+        json.put("filename", "LlamaBridgePlugin.kt")
+        json.put("timestamp", java.time.Instant.now().toString())
+        json.put("classname", "LlamaBridgePlugin")
+        json.put("function", function)
+        json.put("system_section", "plugin")
+        json.put("line_num", 0)
+        json.put("error", "false")
+        json.put("db_phase", "none")
+        json.put("method", "NONE")
+        json.put("message", message)
+        println(json.toString())
+        println("The 17 Commandments of Quality Code")
+    }
+
+    override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        context = binding.applicationContext
+        System.loadLibrary("llama")
+        methodChannel = MethodChannel(binding.binaryMessenger, "llama_bridge/methods")
+        methodChannel.setMethodCallHandler(this)
+        eventChannel = EventChannel(binding.binaryMessenger, "llama_bridge/tokens")
+        eventChannel.setStreamHandler(this)
+    }
+
+    override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        methodChannel.setMethodCallHandler(null)
+        eventChannel.setStreamHandler(null)
+    }
+
+    override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        when (call.method) {
+            "initialize" -> {
+                val model = call.argument<String>("model") ?: return result.error("-1", "model missing", null)
+                val url = call.argument<String>("downloadUrl")
+                val file = prepareModel(context, model, url)
+                val ok = init(file.absolutePath)
+                val mem = Runtime.getRuntime().maxMemory() / (1024 * 1024)
+                val capable = mem > 3000 && ok
+                log("initialize", "capable=$capable mem=$mem")
+                result.success(capable)
+            }
+            "startInference" -> {
+                val prompt = call.argument<String>("prompt") ?: return result.error("-1", "prompt missing", null)
+                infer(prompt)
+                result.success(null)
+            }
+            else -> result.notImplemented()
+        }
+    }
+
+    override fun onListen(arguments: Any?, events: EventChannel.EventSink) {
+        sink = events
+    }
+
+    override fun onCancel(arguments: Any?) {
+        sink = null
+    }
+
+    private fun prepareModel(ctx: Context, assetName: String, downloadUrl: String?): File {
+        val out = File(ctx.filesDir, assetName)
+        if (!out.exists()) {
+            if (downloadUrl != null) {
+                log("prepareModel", "downloading $downloadUrl")
+                URL(downloadUrl).openStream().use { input ->
+                    FileOutputStream(out).use { output ->
+                        input.copyTo(output)
+                    }
+                }
+            } else {
+                log("prepareModel", "copying asset $assetName")
+                ctx.assets.open(assetName).use { input ->
+                    FileOutputStream(out).use { output ->
+                        input.copyTo(output)
+                    }
+                }
+            }
+        }
+        return out
+    }
+
+    @Keep
+    fun onToken(token: String) {
+        sink?.success(token)
+    }
+}

--- a/client_flutter/lib/llama_bridge.dart
+++ b/client_flutter/lib/llama_bridge.dart
@@ -1,0 +1,57 @@
+import 'dart:async';
+import 'dart:convert';
+import 'package:flutter/services.dart';
+import 'package:http/http.dart' as http;
+
+void _log(String classname, String function, String message) {
+  final log = {
+    'filename': 'lib/llama_bridge.dart',
+    'timestamp': DateTime.now().toIso8601String(),
+    'classname': classname,
+    'function': function,
+    'system_section': 'plugin',
+    'line_num': 0,
+    'error': 'false',
+    'db_phase': 'none',
+    'method': 'NONE',
+    'message': message,
+  };
+  print(jsonEncode(log));
+  print('The 17 Commandments of Quality Code');
+}
+
+class LlamaBridge {
+  LlamaBridge._();
+  static const MethodChannel _channel = MethodChannel('llama_bridge/methods');
+  static const EventChannel _events = EventChannel('llama_bridge/tokens');
+
+  static bool _useRemote = false;
+  static Uri? _remoteUrl;
+
+  static Future<void> initialize({required String modelAsset, Uri? downloadUrl, Uri? remoteUrl}) async {
+    _remoteUrl = remoteUrl;
+    final bool? localReady = await _channel.invokeMethod('initialize', {
+      'model': modelAsset,
+      'downloadUrl': downloadUrl?.toString(),
+    });
+    _useRemote = !(localReady ?? true);
+    _log('LlamaBridge', 'initialize', 'useRemote=$_useRemote');
+  }
+
+  static Stream<String> infer(String prompt) {
+    if (_useRemote && _remoteUrl != null) {
+      final controller = StreamController<String>();
+      final req = http.Request('POST', _remoteUrl!);
+      req.body = prompt;
+      http.Client().send(req).then((resp) {
+        resp.stream.transform(utf8.decoder).transform(const LineSplitter()).listen((line) {
+          controller.add(line);
+        }, onError: controller.addError, onDone: controller.close);
+      });
+      return controller.stream;
+    }
+    final stream = _events.receiveBroadcastStream({'prompt': prompt}).cast<String>();
+    _channel.invokeMethod('startInference', {'prompt': prompt});
+    return stream;
+  }
+}

--- a/client_flutter/pubspec.yaml
+++ b/client_flutter/pubspec.yaml
@@ -1,0 +1,15 @@
+name: llama_bridge
+description: Flutter plugin for local llama.cpp inference.
+version: 0.1.0
+environment:
+  sdk: ">=3.0.0 <4.0.0"
+dependencies:
+  flutter:
+    sdk: flutter
+  http: ^1.1.0
+flutter:
+  plugin:
+    platforms:
+      android:
+        package: com.example.llamabridge
+        pluginClass: LlamaBridgePlugin

--- a/client_flutter/test/llama_bridge_test.dart
+++ b/client_flutter/test/llama_bridge_test.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:llama_bridge/llama_bridge.dart';
+
+void main() {
+  test('infer returns stream', () {
+    final stream = LlamaBridge.infer('hello');
+    expect(stream, isA<Stream<String>>());
+  });
+}

--- a/scripts/build_llama_android.sh
+++ b/scripts/build_llama_android.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Structured log helper
+log(){
+  local message="$1"
+  echo '{"filename":"build_llama_android.sh","timestamp":"'$(date -Iseconds)'","classname":"build_script","function":"log","system_section":"build","line_num":'${BASH_LINENO[0]}',"error":"false","db_phase":"none","method":"NONE","message":"'$message'"}'
+  echo "The 17 Commandments of Quality Code"
+}
+
+# Check for Android NDK
+if [[ -z "${ANDROID_NDK_HOME:-}" ]]; then
+  log "ANDROID_NDK_HOME not set" >&2
+  exit 1
+fi
+
+LLAMA_COMMIT="c9a4f1c" # fixed commit for compatibility
+WORK_DIR="$(pwd)/../build_llama"
+rm -rf "$WORK_DIR"
+mkdir -p "$WORK_DIR"
+cd "$WORK_DIR"
+
+log "Cloning llama.cpp"
+if [[ ! -d llama.cpp ]]; then
+  git clone https://github.com/ggerganov/llama.cpp.git
+  cd llama.cpp
+  git checkout "$LLAMA_COMMIT"
+else
+  cd llama.cpp
+  git fetch origin "$LLAMA_COMMIT"
+  git checkout "$LLAMA_COMMIT"
+fi
+
+log "Configuring build with CMake"
+cmake -S . -B build-android \
+  -DANDROID_ABI=arm64-v8a \
+  -DANDROID_PLATFORM=android-24 \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DANDROID_NDK="$ANDROID_NDK_HOME" \
+  -DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake"
+
+log "Building llama.cpp for Android"
+cmake --build build-android --target llama
+
+OUTPUT_DIR="$(dirname "$WORK_DIR")/client_flutter/android/src/main/jniLibs/arm64-v8a"
+mkdir -p "$OUTPUT_DIR"
+cp build-android/libllama.so "$OUTPUT_DIR"
+log "libllama.so copied to $OUTPUT_DIR"
+


### PR DESCRIPTION
## Summary
- add build script to compile llama.cpp for Android NDK
- introduce Flutter plugin that streams tokens from native inference and falls back to remote server when device resources are low
- include basic test scaffold for plugin

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1356f968832bbbd16af798ccb223