### PR TITLE
Add whisper.cpp STT and audio normalization

### DIFF
--- a/server/android_speech_stt_service.py
+++ b/server/android_speech_stt_service.py
@@ -43,8 +43,8 @@ class AndroidSpeechSTTService(STTService):
             audio_google = speech.RecognitionAudio(content=audio_norm)
             response = await asyncio.to_thread(
                 self._client.recognize,
-                config,
-                audio_google,
+                config=config,
+                audio=audio_google,
             )
             await self.stop_ttfb_metrics()
             await self.stop_processing_metrics()

--- a/server/android_speech_stt_service.py
+++ b/server/android_speech_stt_service.py
@@ -1,0 +1,62 @@
+"""Android Speech API STT service using Google Cloud Speech."""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncGenerator
+
+from google.cloud import speech
+from loguru import logger
+from pipecat.frames.frames import ErrorFrame, Frame, TranscriptionFrame
+from pipecat.services.stt_service import STTService
+from pipecat.utils.datetime import time_now_iso8601
+
+from .audio_utils import ensure_pcm16, TARGET_SAMPLE_RATE
+
+
+class AndroidSpeechSTTService(STTService):
+    """Speech-to-text using Google Cloud's Speech-to-Text API."""
+
+    def __init__(self, credentials_path: str | None = None, **kwargs):
+        super().__init__(sample_rate=TARGET_SAMPLE_RATE, **kwargs)
+        if credentials_path:
+            self._client = speech.SpeechClient.from_service_account_file(
+                credentials_path
+            )
+        else:
+            self._client = speech.SpeechClient()
+        self._settings = {"engine": "android"}
+
+    async def run_stt(self, audio: bytes) -> AsyncGenerator[Frame, None]:
+        try:
+            await self.start_processing_metrics()
+            await self.start_ttfb_metrics()
+            audio_norm = ensure_pcm16(
+                audio,
+                self.sample_rate,
+                TARGET_SAMPLE_RATE,
+            )
+            config = speech.RecognitionConfig(
+                encoding=speech.RecognitionConfig.AudioEncoding.LINEAR16,
+                sample_rate_hertz=TARGET_SAMPLE_RATE,
+                language_code="en-US",
+            )
+            audio_google = speech.RecognitionAudio(content=audio_norm)
+            response = await asyncio.to_thread(
+                self._client.recognize,
+                config,
+                audio_google,
+            )
+            await self.stop_ttfb_metrics()
+            await self.stop_processing_metrics()
+            for result in response.results:
+                text = result.alternatives[0].transcript.strip()
+                if text:
+                    yield TranscriptionFrame(
+                        text,
+                        self._user_id,
+                        time_now_iso8601(),
+                        None,
+                    )
+        except Exception as e:
+            logger.exception(f"Android Speech transcription error: {e}")
+            yield ErrorFrame(f"Android Speech transcription error: {e}")

--- a/server/audio_utils.py
+++ b/server/audio_utils.py
@@ -1,0 +1,30 @@
+"""Audio utilities for normalization."""
+from __future__ import annotations
+
+import numpy as np
+from scipy import signal
+
+TARGET_SAMPLE_RATE = 24000
+
+
+def ensure_pcm16(
+    audio: bytes,
+    source_rate: int,
+    target_rate: int = TARGET_SAMPLE_RATE,
+) -> bytes:
+    """Normalize raw PCM audio to 16-bit, target sample rate.
+
+    Args:
+        audio: Input audio bytes (16-bit PCM).
+        source_rate: Sample rate of the input audio.
+        target_rate: Desired output sample rate (default: 24kHz).
+    Returns:
+        Bytes of normalized 16-bit PCM audio at target sample rate.
+    """
+    audio_np = np.frombuffer(audio, dtype=np.int16).astype(np.float32)
+    if source_rate != target_rate:
+        audio_np = signal.resample(
+            audio_np, int(len(audio_np) * target_rate / source_rate)
+        )
+    audio_int16 = np.clip(audio_np, -32768, 32767).astype(np.int16)
+    return audio_int16.tobytes()

--- a/server/bot.py
+++ b/server/bot.py
@@ -1,14 +1,9 @@
 import argparse
 import asyncio
 import os
-import sys
 from contextlib import asynccontextmanager
 from typing import Dict
 
-# Add local pipecat to Python path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "pipecat", "src"))
-
-from kokoro_tts import KokoroTTSService
 import uvicorn
 from dotenv import load_dotenv
 from fastapi import BackgroundTasks, FastAPI
@@ -23,9 +18,10 @@ from pipecat.pipeline.runner import PipelineRunner
 from pipecat.pipeline.task import PipelineParams, PipelineTask
 from pipecat.processors.aggregators.openai_llm_context import OpenAILLMContext
 from pipecat.services.openai.llm import OpenAILLMService
-# from kokoro_tts import KokoroTTSService
 from kittentts_service import KittenTTSService
-from pipecat.services.whisper.stt import WhisperSTTServiceMLX, MLXModel
+from kokoro_tts import KokoroTTSService
+from whispercpp_stt_service import WhisperCPPSTTService
+from android_speech_stt_service import AndroidSpeechSTTService
 from pipecat.transports.base_transport import TransportParams
 from pipecat.processors.frameworks.rtvi import RTVIConfig, RTVIObserver, RTVIProcessor
 from pipecat.transports.network.small_webrtc import SmallWebRTCTransport
@@ -73,11 +69,25 @@ async def run_bot(webrtc_connection):
         ),
     )
 
-    stt = WhisperSTTServiceMLX(model=MLXModel.LARGE_V3_TURBO_Q4)
+    stt_engine = os.getenv("STT_ENGINE", "whispercpp").lower()
+    if stt_engine == "android":
+        stt = AndroidSpeechSTTService(
+            os.getenv("ANDROID_SPEECH_CREDENTIALS")
+        )
+    else:
+        model_path = os.getenv("WHISPERCPP_MODEL", "ggml-base.en.bin")
+        stt = WhisperCPPSTTService(model_path=model_path)
 
-    #tts = KokoroTTSService(model="prince-canuma/Kokoro-82M", voice="af_heart", sample_rate=24000)
-    # Process-isolated version to avoid Metal assertion failures (now refactored to use standalone worker)
-    tts = KittenTTSService()
+    tts_engine = os.getenv("TTS_ENGINE", "kitten").lower()
+    if tts_engine == "kokoro":
+        tts = KokoroTTSService(
+            model=os.getenv("KOKORO_MODEL", "prince-canuma/Kokoro-82M"),
+            voice=os.getenv("KOKORO_VOICE", "af_heart"),
+            sample_rate=24000,
+        )
+    else:
+        # Process-isolated version to avoid Metal assertion failures (now refactored to use standalone worker)
+        tts = KittenTTSService()
 
     llm = OpenAILLMService(
         api_key="not-needed",  # Ollama doesn't require API key

--- a/server/kittentts_service.py
+++ b/server/kittentts_service.py
@@ -22,6 +22,7 @@ from pipecat.frames.frames import (
 )
 from pipecat.services.tts_service import TTSService
 from pipecat.utils.tracing.service_decorators import traced_tts
+from .audio_utils import ensure_pcm16
 
 
 class KittenTTSService(TTSService):
@@ -209,7 +210,7 @@ class KittenTTSService(TTSService):
             # Ensure audio is 1D array
             if len(audio_array.shape) > 1:
                 audio_array = audio_array.squeeze()
-            
+
             # Normalize and convert to 16-bit PCM
             # KittenTTS typically returns normalized float32 audio
             if audio_array.dtype == np.float32 or audio_array.dtype == np.float64:
@@ -220,9 +221,10 @@ class KittenTTSService(TTSService):
             else:
                 # Already in int16 format
                 audio_int16 = audio_array.astype(np.int16)
-            
+
             audio_bytes = audio_int16.tobytes()
-            
+            audio_bytes = ensure_pcm16(audio_bytes, self.sample_rate)
+
             logger.debug(f"Generated {len(audio_bytes)} bytes of audio")
             return audio_bytes
             

--- a/server/kokoro_tts.py
+++ b/server/kokoro_tts.py
@@ -21,6 +21,7 @@ from pipecat.frames.frames import (
 )
 from pipecat.services.tts_service import TTSService
 from pipecat.utils.tracing.service_decorators import traced_tts
+from .audio_utils import ensure_pcm16
 
 
 class KokoroTTSService(TTSService):
@@ -112,6 +113,7 @@ class KokoroTTSService(TTSService):
             # MLX audio returns float32 normalized audio
             audio_int16 = (audio_np * 32767).astype(np.int16)
             audio_bytes = audio_int16.tobytes()
+            audio_bytes = ensure_pcm16(audio_bytes, self.sample_rate)
 
             return audio_bytes
 

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -10,5 +10,8 @@ nltk
 kittentts>=0.1.0
 soundfile
 huggingface_hub
+scipy>=1.11.4
+whispercpp>=0.0.17
+google-cloud-speech>=2.27.0
 
 

--- a/server/whispercpp_stt_service.py
+++ b/server/whispercpp_stt_service.py
@@ -1,0 +1,55 @@
+"""Whisper.cpp-based STT service."""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncGenerator
+
+import numpy as np
+from loguru import logger
+from pipecat.frames.frames import ErrorFrame, Frame, TranscriptionFrame
+from pipecat.services.stt_service import STTService
+from pipecat.utils.datetime import time_now_iso8601
+
+from .audio_utils import ensure_pcm16, TARGET_SAMPLE_RATE
+
+
+class WhisperCPPSTTService(STTService):
+    """Speech-to-text using whisper.cpp bindings."""
+
+    def __init__(self, model_path: str, **kwargs):
+        super().__init__(sample_rate=TARGET_SAMPLE_RATE, **kwargs)
+        import whispercpp
+
+        self._model = whispercpp.Whisper(model_path)
+        self._settings = {"engine": "whispercpp"}
+
+    async def run_stt(self, audio: bytes) -> AsyncGenerator[Frame, None]:
+        try:
+            await self.start_processing_metrics()
+            await self.start_ttfb_metrics()
+            audio_norm = ensure_pcm16(
+                audio,
+                self.sample_rate,
+                TARGET_SAMPLE_RATE,
+            )
+            audio_float = (
+                np.frombuffer(audio_norm, dtype=np.int16).astype(np.float32)
+                / 32768.0
+            )
+            result = await asyncio.to_thread(
+                self._model.transcribe,
+                audio_float,
+            )
+            text = result.get("text", "").strip()
+            await self.stop_ttfb_metrics()
+            await self.stop_processing_metrics()
+            if text:
+                yield TranscriptionFrame(
+                    text,
+                    self._user_id,
+                    time_now_iso8601(),
+                    self._settings.get("language"),
+                )
+        except Exception as e:
+            logger.exception(f"whisper.cpp transcription error: {e}")
+            yield ErrorFrame(f"Whisper.cpp transcription error: {e}")


### PR DESCRIPTION
## Summary
- integrate whisper.cpp offline STT with optional Android Speech API fallback
- normalize audio pipeline to 16-bit PCM 24kHz and expose Kokoro TTS option
- document dependencies for new audio pipeline components

## Testing
- `flake8 audio_utils.py whispercpp_stt_service.py android_speech_stt_service.py bot.py` *(fails: line too long in bot.py)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa13586650832b94372eeb093207d5