### PR TITLE
Add cached KittenTTS synthesis and regression tests

### DIFF
--- a/server/bot.py
+++ b/server/bot.py
@@ -146,6 +146,13 @@ def _get_cached_stt_service():
 _STT_TRANSCRIBE_LOCK = Lock()
 
 
+@lru_cache(maxsize=1)
+def _get_cached_tts_service() -> KittenTTSService:
+    """Return a cached KittenTTS service instance for reuse."""
+
+    return KittenTTSService()
+
+
 def _log_event(function: str, message: str, method: str, error: str | None = None) -> None:
     """Emit structured log events and derived human-readable line."""
 
@@ -344,8 +351,18 @@ async def mobile_endpoint(
 
     response_text = f"You said: {transcript}"
 
-    tts = KittenTTSService()
-    audio_out = await loop.run_in_executor(None, tts.synthesize, response_text)
+    try:
+        tts = _get_cached_tts_service()
+    except Exception as exc:  # pragma: no cover - defensive guard for init failures
+        _log_event("mobile_endpoint", "tts_unavailable", "POST", error=str(exc))
+        raise HTTPException(status_code=503, detail="Text-to-speech service unavailable") from exc
+
+    try:
+        audio_out = await loop.run_in_executor(None, tts.synthesize, response_text)
+    except Exception as exc:
+        _log_event("mobile_endpoint", "tts_failure", "POST", error=str(exc))
+        raise HTTPException(status_code=500, detail="Failed to synthesize speech") from exc
+
     _log_event("mobile_endpoint", "generated_audio", "POST")
 
     return Response(content=audio_out, media_type="audio/wav")

--- a/server/kittentts_service.py
+++ b/server/kittentts_service.py
@@ -1,11 +1,14 @@
 import asyncio
 import concurrent.futures
-from typing import AsyncGenerator, Optional
-import numpy as np
-from loguru import logger
+import io
 import os
 import sys
+import wave
 from pathlib import Path
+from typing import AsyncGenerator, Optional
+
+import numpy as np
+from loguru import logger
 
 try:
     from kittentts import KittenTTS
@@ -187,21 +190,29 @@ class KittenTTSService(TTSService):
     def can_generate_metrics(self) -> bool:
         return True
     
-    def _generate_audio_sync(self, text: str) -> bytes:
+    def _generate_audio_sync(self, text: str, *, voice: Optional[str] = None) -> bytes:
         """Synchronously generate audio from text. This runs in a separate thread."""
         try:
             if self._init_future:
                 self._init_future.result()  # Wait for initialization
                 self._init_future = None
-            
+
             if self._model is None:
                 raise ValueError("Model not initialized")
-            
+
+            voice_to_use = voice or self._voice
+            if voice and voice not in self._available_voices:
+                logger.warning(
+                    "Requested voice '%s' not in known voices; attempting generation anyway",
+                    voice,
+                )
+
+            self._settings["voice"] = voice_to_use
             logger.debug(f"Generating audio for: {text}")
-            
+
             # Generate audio using KittenTTS
             # KittenTTS returns a numpy array with audio samples
-            audio_array = self._model.generate(text, voice=self._voice)
+            audio_array = self._model.generate(text, voice=voice_to_use)
             
             if audio_array is None or len(audio_array) == 0:
                 raise ValueError("No audio generated")
@@ -222,13 +233,42 @@ class KittenTTSService(TTSService):
                 audio_int16 = audio_array.astype(np.int16)
             
             audio_bytes = audio_int16.tobytes()
-            
+
             logger.debug(f"Generated {len(audio_bytes)} bytes of audio")
             return audio_bytes
-            
+
         except Exception as e:
             logger.error(f"Error generating audio: {e}")
             raise
+
+    def synthesize(self, text: str, *, voice: Optional[str] = None) -> bytes:
+        """Generate a WAV payload for the provided text.
+
+        Args:
+            text: Text that should be converted to speech.
+            voice: Optional override for the configured voice.
+
+        Returns:
+            Bytes representing a 16-bit mono WAV file at the configured sample rate.
+        """
+
+        if not text or not text.strip():
+            raise ValueError("Text to synthesize must be a non-empty string")
+
+        logger.debug("Synthesizing TTS for %s characters", len(text))
+        pcm_audio = self._generate_audio_sync(text, voice=voice)
+        target_sample_rate = int(
+            self._settings.get("sample_rate") or self.sample_rate or 24000
+        )
+
+        buffer = io.BytesIO()
+        with wave.open(buffer, "wb") as wav_file:
+            wav_file.setnchannels(1)
+            wav_file.setsampwidth(2)  # 16-bit audio
+            wav_file.setframerate(target_sample_rate)
+            wav_file.writeframes(pcm_audio)
+
+        return buffer.getvalue()
     
     @traced_tts
     async def run_tts(self, text: str) -> AsyncGenerator[Frame, None]:

--- a/server/test_kittentts_service_unit.py
+++ b/server/test_kittentts_service_unit.py
@@ -1,0 +1,52 @@
+import importlib.util
+import io
+import sys
+import types
+import wave
+from pathlib import Path
+
+import numpy as np
+
+
+def _load_test_service(monkeypatch):
+    module_name = "server.kittentts_service_testdouble"
+    module_path = Path(__file__).resolve().parent / "kittentts_service.py"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_synthesize_produces_wav_payload(monkeypatch):
+    stub_module = types.ModuleType("kittentts")
+
+    class _StubKittenTTS:
+        last_call: tuple[str, str] | None = None
+
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def generate(self, text: str, voice: str = "expr-voice-2-f"):
+            type(self).last_call = (text, voice)
+            return np.array([0.0, 0.25, -0.25, 0.5, -0.5], dtype=np.float32)
+
+    stub_module.KittenTTS = _StubKittenTTS
+    monkeypatch.setitem(sys.modules, "kittentts", stub_module)
+
+    module = _load_test_service(monkeypatch)
+    service = module.KittenTTSService(sample_rate=16000)
+
+    wav_bytes = service.synthesize("Hello world", voice="expr-voice-3-f")
+
+    with wave.open(io.BytesIO(wav_bytes), "rb") as wav_file:
+        assert wav_file.getnchannels() == 1
+        assert wav_file.getsampwidth() == 2
+        assert wav_file.getframerate() == 16000
+        frames = wav_file.readframes(wav_file.getnframes())
+
+    pcm = np.frombuffer(frames, dtype=np.int16)
+    assert pcm.size > 0
+    assert pcm.max() != 0 or pcm.min() != 0
+    assert service._settings["sample_rate"] == 16000
+    assert _StubKittenTTS.last_call == ("Hello world", "expr-voice-3-f")

--- a/server/test_mobile_endpoint.py
+++ b/server/test_mobile_endpoint.py
@@ -88,6 +88,8 @@ def _prepare_env(monkeypatch):
     )
     import server.bot as bot  # noqa
     reload(bot)
+    if hasattr(bot._get_cached_tts_service, "cache_clear"):
+        bot._get_cached_tts_service.cache_clear()
     return token, bot
 
 
@@ -104,7 +106,7 @@ def test_mobile_endpoint_success(monkeypatch):
 
     monkeypatch.setattr(bot, "_create_stt_service", lambda: FakeSTT())
     monkeypatch.setattr(bot, "_get_cached_stt_service", lambda: FakeSTT())
-    monkeypatch.setattr(bot, "KittenTTSService", lambda *a, **k: FakeTTS())
+    monkeypatch.setattr(bot, "_get_cached_tts_service", lambda: FakeTTS())
 
     client = TestClient(bot.app)
     audio = _sample_wav_bytes()
@@ -142,7 +144,7 @@ def test_mobile_endpoint_logs_success_flow(monkeypatch):
 
     monkeypatch.setattr(bot, "_create_stt_service", lambda: FakeSTT())
     monkeypatch.setattr(bot, "_get_cached_stt_service", lambda: FakeSTT())
-    monkeypatch.setattr(bot, "KittenTTSService", lambda *a, **k: FakeTTS())
+    monkeypatch.setattr(bot, "_get_cached_tts_service", lambda: FakeTTS())
 
     events = []
 
@@ -212,3 +214,26 @@ def test_mobile_endpoint_logs_unauthorized(monkeypatch):
 
     assert any(entry["message"] == "unauthorized" and entry["error"] == "unauthorized" for entry in structured)
     assert any("error=unauthorized" in line for line in derived)
+
+
+def test_cached_tts_service_reuses_instance(monkeypatch):
+    token, bot = _prepare_env(monkeypatch)
+
+    created_instances = []
+
+    class _FakeTTS:
+        pass
+
+    def _factory():
+        instance = _FakeTTS()
+        created_instances.append(instance)
+        return instance
+
+    bot._get_cached_tts_service.cache_clear()
+    monkeypatch.setattr(bot, "KittenTTSService", _factory)
+
+    first = bot._get_cached_tts_service()
+    second = bot._get_cached_tts_service()
+
+    assert first is second
+    assert len(created_instances) == 1

--- a/task.md
+++ b/task.md
@@ -5,3 +5,7 @@
 - [x] Verify end-to-end voice agent startup on macOS/Linux, including Pipecat, Whisper, Ollama, and KittenTTS integration.
 - [x] Expand automated test coverage for mobile audio endpoint and structured logging.
 - [x] Document dependency versions and update installation instructions where necessary.
+
+## Remake Tasks
+- [x] Implement cached KittenTTS synthesis for the mobile endpoint with resilient error handling.
+- [x] Add regression tests that validate KittenTTS WAV output and cache behavior.


### PR DESCRIPTION
## Summary
- reuse a cached KittenTTS service for the mobile endpoint and surface explicit error logs when synthesis fails
- add a synchronous KittenTTS `synthesize` helper that emits WAV bytes with configurable voices and sample rate fallback
- expand mobile endpoint coverage and add a unit test that validates the generated WAV payload

## Testing
- pytest
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68eaf0bcdde4832b803f3def20683af3