### PR TITLE
Enhance Flutter LlamaBridge remote fallback and tests

### DIFF
--- a/client_flutter/lib/llama_bridge.dart
+++ b/client_flutter/lib/llama_bridge.dart
@@ -2,8 +2,15 @@ import 'dart:async';
 import 'dart:convert';
 import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
+import 'package:meta/meta.dart';
 
-void _log(String classname, String function, String message) {
+void _log(
+  String classname,
+  String function,
+  String message, {
+  bool isError = false,
+  String method = 'NONE',
+}) {
   final log = {
     'filename': 'lib/llama_bridge.dart',
     'timestamp': DateTime.now().toIso8601String(),
@@ -11,13 +18,13 @@ void _log(String classname, String function, String message) {
     'function': function,
     'system_section': 'plugin',
     'line_num': 0,
-    'error': 'false',
+    'error': isError,
     'db_phase': 'none',
-    'method': 'NONE',
+    'method': method,
     'message': message,
   };
   print(jsonEncode(log));
-  print('The 17 Commandments of Quality Code');
+  print('[Continuous skepticism (Sherlock Protocol)] $message');
 }
 
 class LlamaBridge {
@@ -27,6 +34,7 @@ class LlamaBridge {
 
   static bool _useRemote = false;
   static Uri? _remoteUrl;
+  static http.Client Function() _httpClientFactory = http.Client.new;
 
   static Future<void> initialize({required String modelAsset, Uri? downloadUrl, Uri? remoteUrl}) async {
     _remoteUrl = remoteUrl;
@@ -35,23 +43,133 @@ class LlamaBridge {
       'downloadUrl': downloadUrl?.toString(),
     });
     _useRemote = !(localReady ?? true);
-    _log('LlamaBridge', 'initialize', 'useRemote=$_useRemote');
+    _log('LlamaBridge', 'initialize', 'useRemote=$_useRemote remoteUrl=${_remoteUrl?.toString() ?? 'none'}');
   }
 
   static Stream<String> infer(String prompt) {
     if (_useRemote && _remoteUrl != null) {
-      final controller = StreamController<String>();
-      final req = http.Request('POST', _remoteUrl!);
-      req.body = prompt;
-      http.Client().send(req).then((resp) {
-        resp.stream.transform(utf8.decoder).transform(const LineSplitter()).listen((line) {
-          controller.add(line);
-        }, onError: controller.addError, onDone: controller.close);
-      });
-      return controller.stream;
+      return _inferRemote(prompt);
     }
     final stream = _events.receiveBroadcastStream({'prompt': prompt}).cast<String>();
     _channel.invokeMethod('startInference', {'prompt': prompt});
     return stream;
+  }
+
+  static Stream<String> _inferRemote(String prompt) {
+    final controller = StreamController<String>();
+    late final http.Client client;
+    try {
+      client = _httpClientFactory();
+    } catch (err, stack) {
+      final error = LlamaBridgeRemoteException(
+        'Failed to create HTTP client: $err',
+        cause: err,
+        stackTrace: stack,
+      );
+      _log('LlamaBridge', 'inferRemote', error.message, isError: true, method: 'POST');
+      controller.addError(error);
+      controller.close();
+      return controller.stream;
+    }
+
+    var clientClosed = false;
+    void closeClient() {
+      if (!clientClosed) {
+        client.close();
+        clientClosed = true;
+      }
+    }
+
+    controller.onCancel = closeClient;
+
+    () async {
+      try {
+        final request = http.Request('POST', _remoteUrl!);
+        request.headers['content-type'] = 'text/plain; charset=utf-8';
+        request.body = prompt;
+        _log('LlamaBridge', 'inferRemote', 'dispatching remote inference request', method: 'POST');
+        final response = await client.send(request);
+        if (response.statusCode < 200 || response.statusCode >= 300) {
+          final error = LlamaBridgeRemoteException(
+            'Remote inference failed with status ${response.statusCode}',
+            statusCode: response.statusCode,
+            reason: response.reasonPhrase,
+          );
+          _log('LlamaBridge', 'inferRemote', error.message, isError: true, method: 'POST');
+          controller.addError(error);
+          await controller.close();
+          return;
+        }
+
+        await response.stream
+            .transform(utf8.decoder)
+            .transform(const LineSplitter())
+            .forEach(controller.add);
+        await controller.close();
+      } catch (err, stack) {
+        final error = LlamaBridgeRemoteException(
+          'Remote inference request threw: $err',
+          cause: err,
+          stackTrace: stack,
+        );
+        _log('LlamaBridge', 'inferRemote', error.message, isError: true, method: 'POST');
+        controller.addError(error);
+        await controller.close();
+      } finally {
+        closeClient();
+      }
+    }();
+
+    return controller.stream;
+  }
+
+  @visibleForTesting
+  static void setHttpClientFactory(http.Client Function() factory) {
+    _httpClientFactory = factory;
+  }
+
+  @visibleForTesting
+  static void configureRemoteForTesting({required bool useRemote, Uri? remoteUrl}) {
+    _useRemote = useRemote;
+    _remoteUrl = remoteUrl;
+  }
+
+  @visibleForTesting
+  static void resetTestingOverrides() {
+    _httpClientFactory = http.Client.new;
+    _useRemote = false;
+    _remoteUrl = null;
+  }
+}
+
+class LlamaBridgeRemoteException implements Exception {
+  LlamaBridgeRemoteException(
+    this.message, {
+    this.cause,
+    this.statusCode,
+    this.reason,
+    this.stackTrace,
+  });
+
+  final String message;
+  final Object? cause;
+  final int? statusCode;
+  final String? reason;
+  final StackTrace? stackTrace;
+
+  @override
+  String toString() {
+    final buffer = StringBuffer('LlamaBridgeRemoteException(message: $message');
+    if (statusCode != null) {
+      buffer.write(', statusCode: $statusCode');
+    }
+    if (reason != null) {
+      buffer.write(', reason: $reason');
+    }
+    if (cause != null) {
+      buffer.write(', cause: $cause');
+    }
+    buffer.write(')');
+    return buffer.toString();
   }
 }

--- a/client_flutter/pubspec.yaml
+++ b/client_flutter/pubspec.yaml
@@ -7,6 +7,7 @@ dependencies:
   flutter:
     sdk: flutter
   http: ^1.1.0
+  meta: ^1.11.0
 flutter:
   plugin:
     platforms:

--- a/client_flutter/test/llama_bridge_test.dart
+++ b/client_flutter/test/llama_bridge_test.dart
@@ -1,9 +1,70 @@
+import 'dart:async';
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
 import 'package:llama_bridge/llama_bridge.dart';
 
 void main() {
+  setUp(() {
+    LlamaBridge.resetTestingOverrides();
+  });
+
   test('infer returns stream', () {
     final stream = LlamaBridge.infer('hello');
     expect(stream, isA<Stream<String>>());
   });
+
+  test('streams remote tokens when local model unavailable', () async {
+    const remoteUrl = 'https://example.com/infer';
+    final client = _StreamingClient((request) async {
+      expect(request.method, 'POST');
+      expect(request.url.toString(), remoteUrl);
+      final tokens = ['tok1', 'tok2', 'tok3'];
+      final payload = Stream<List<int>>.fromIterable(
+        tokens.map((token) => utf8.encode('$token\n')),
+      );
+      return http.StreamedResponse(payload, 200);
+    });
+
+    LlamaBridge.configureRemoteForTesting(
+      useRemote: true,
+      remoteUrl: Uri.parse(remoteUrl),
+    );
+    LlamaBridge.setHttpClientFactory(() => client);
+
+    final results = await LlamaBridge.infer('hello world').toList();
+    expect(results, ['tok1', 'tok2', 'tok3']);
+  });
+
+  test('surfaces remote HTTP failures as errors', () async {
+    const remoteUrl = 'https://example.com/infer';
+    final client = _StreamingClient((_) async {
+      final empty = Stream<List<int>>.empty();
+      return http.StreamedResponse(empty, 503, reasonPhrase: 'unavailable');
+    });
+
+    LlamaBridge.configureRemoteForTesting(
+      useRemote: true,
+      remoteUrl: Uri.parse(remoteUrl),
+    );
+    LlamaBridge.setHttpClientFactory(() => client);
+
+    final stream = LlamaBridge.infer('prompt');
+    await expectLater(
+      stream,
+      emitsError(
+        isA<LlamaBridgeRemoteException>().having((e) => e.statusCode, 'statusCode', 503),
+      ),
+    );
+  });
+}
+
+class _StreamingClient extends http.BaseClient {
+  _StreamingClient(this._handler);
+
+  final Future<http.StreamedResponse> Function(http.BaseRequest request) _handler;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) => _handler(request);
 }

--- a/task.md
+++ b/task.md
@@ -9,3 +9,8 @@
 ## Remake Tasks
 - [x] Implement cached KittenTTS synthesis for the mobile endpoint with resilient error handling.
 - [x] Add regression tests that validate KittenTTS WAV output and cache behavior.
+
+## LlamaBridge Enhancements
+- [x] Emit canonical structured logs with derived skepticism line from the Flutter bridge.
+- [x] Support injectable HTTP clients and robust remote fallback handling in `LlamaBridge`.
+- [x] Expand Flutter unit coverage for remote token streaming and HTTP error surfacing.


### PR DESCRIPTION
## Summary
- add structured logging with the Continuous skepticism derived line and injectable HTTP client support to LlamaBridge
- implement resilient remote inference streaming with surfaced errors and testing hooks
- cover remote token streaming and HTTP failure cases in Flutter unit tests and document completion in task.md

## Testing
- flutter test *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68eaf5c388c4832ba712a6720a42fb5b