### PR TITLE
Add macOS and Linux setup/run scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@ chmod +x *.sh
 ### 📋 **Script Usage Order**
 
 **First Time Setup:**
-1. **`./setup_kittentts.sh`** - Install KittenTTS dependencies (run once)
-2. **`./start.sh`** - Start the full application
+1. **macOS:** `./setup_mac.sh`
+2. **Linux:** `./setup_linux.sh`
+3. **Optional:** `./setup_kittentts.sh` - deeper KittenTTS diagnostics
+4. **Then:** `./run_mac.sh` or `./run_linux.sh`
 
 **Regular Usage:**
 - **`./start.sh`** - Start everything (server + client)
@@ -41,25 +43,38 @@ chmod +x *.sh
 
 ---
 
-### Option 1: One-Command Setup (Recommended)
+### Option 1: macOS Setup (Recommended)
 ```bash
-# Clone and setup everything automatically
+# Clone and setup everything automatically on macOS
 git clone <repository-url>
 cd macos-local-voice-agents-main
 chmod +x *.sh
-./start.sh
+./setup_mac.sh
+./run_mac.sh
 ```
 
-### Option 2: KittenTTS Quick Start
+### Option 2: Linux Setup (Recommended)
 ```bash
-# For first-time KittenTTS setup
+# Clone and setup everything automatically on Linux
+git clone <repository-url>
+cd macos-local-voice-agents-main
+chmod +x *.sh
+./setup_linux.sh
+./run_linux.sh
+```
+
+### Option 3: KittenTTS Quick Start
+```bash
+# For first-time KittenTTS setup or to diagnose voice synthesis
 ./setup_kittentts.sh
 
-# Then start the agent
-./start.sh
+# Then start the agent after running the OS-specific setup
+./run_mac.sh   # macOS
+# or
+./run_linux.sh # Linux
 ```
 
-### Option 3: Manual Setup
+### Option 4: Manual Setup
 ```bash
 # Setup Python environment
 python3 -m venv venv

--- a/run_linux.sh
+++ b/run_linux.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euo pipefail
+
+OS_NAME="$(uname -s)"
+if [[ "$OS_NAME" != "Linux" ]]; then
+    echo "[ERROR] run_linux.sh must be executed on Linux. Detected: $OS_NAME" >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$SCRIPT_DIR"
+VENV_DIR="$PROJECT_ROOT/venv"
+CLIENT_NODE_MODULES="$PROJECT_ROOT/client/node_modules"
+
+if [[ ! -d "$VENV_DIR" ]]; then
+    echo "[ERROR] Python virtual environment missing. Run ./setup_linux.sh first." >&2
+    exit 1
+fi
+
+if [[ ! -d "$CLIENT_NODE_MODULES" ]]; then
+    echo "[ERROR] Node.js dependencies missing. Run ./setup_linux.sh before starting." >&2
+    exit 1
+fi
+
+source "$VENV_DIR/bin/activate"
+trap 'deactivate >/dev/null 2>&1 || true' EXIT
+
+if ! python -c "import faster_whisper" >/dev/null 2>&1; then
+    echo "[WARNING] faster_whisper import check failed. Setup may be incomplete." >&2
+fi
+
+deactivate
+trap - EXIT
+
+exec "$PROJECT_ROOT/start.sh"

--- a/run_mac.sh
+++ b/run_mac.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euo pipefail
+
+OS_NAME="$(uname -s)"
+if [[ "$OS_NAME" != "Darwin" ]]; then
+    echo "[ERROR] run_mac.sh must be executed on macOS (Darwin). Detected: $OS_NAME" >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$SCRIPT_DIR"
+VENV_DIR="$PROJECT_ROOT/venv"
+CLIENT_NODE_MODULES="$PROJECT_ROOT/client/node_modules"
+
+if [[ ! -d "$VENV_DIR" ]]; then
+    echo "[ERROR] Python virtual environment missing. Run ./setup_mac.sh first." >&2
+    exit 1
+fi
+
+if [[ ! -d "$CLIENT_NODE_MODULES" ]]; then
+    echo "[ERROR] Node.js dependencies missing. Run ./setup_mac.sh before starting." >&2
+    exit 1
+fi
+
+source "$VENV_DIR/bin/activate"
+trap 'deactivate >/dev/null 2>&1 || true' EXIT
+
+if ! python -c "import kokoro_tts" >/dev/null 2>&1; then
+    echo "[WARNING] kokoro_tts import check failed. Setup may be incomplete." >&2
+fi
+
+deactivate
+trap - EXIT
+
+exec "$PROJECT_ROOT/start.sh"

--- a/setup_linux.sh
+++ b/setup_linux.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+set -euo pipefail
+
+OS_NAME="$(uname -s)"
+if [[ "$OS_NAME" != "Linux" ]]; then
+    echo "[ERROR] setup_linux.sh must be run on Linux. Detected: $OS_NAME" >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$SCRIPT_DIR"
+VENV_DIR="$PROJECT_ROOT/venv"
+LOG_DIR="$PROJECT_ROOT/logs"
+
+info() { echo "[INFO] $1"; }
+success() { echo "[SUCCESS] $1"; }
+warning() { echo "[WARNING] $1"; }
+error() { echo "[ERROR] $1" >&2; }
+
+require_command() {
+    local cmd="$1"
+    local instructions="$2"
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        error "Missing required command: $cmd"
+        echo "$instructions" >&2
+        exit 1
+    fi
+}
+
+install_apt_packages() {
+    local packages=("$@")
+    if command -v apt-get >/dev/null 2>&1; then
+        local runner="apt-get"
+        if command -v sudo >/dev/null 2>&1 && [[ $EUID -ne 0 ]]; then
+            runner="sudo apt-get"
+        elif [[ $EUID -ne 0 ]]; then
+            warning "sudo is unavailable; attempting direct apt-get install may fail without privileges."
+        fi
+        info "Installing apt packages: ${packages[*]}"
+        $runner update
+        $runner install -y "${packages[@]}"
+    else
+        warning "apt-get not found. Please install the following packages manually: ${packages[*]}"
+    fi
+}
+
+info "Detected Linux. Preparing environment in $PROJECT_ROOT"
+
+require_command "python3" "Install Python 3 (3.11 or newer) via your distribution package manager."
+require_command "pip" "Install pip for Python 3: python3 -m ensurepip --upgrade"
+require_command "npm" "Install Node.js 18+ using your distro package manager or NodeSource binaries."
+
+install_apt_packages python3-venv python3-dev build-essential ffmpeg sox portaudio19-dev libsndfile1
+
+if [[ ! -d "$VENV_DIR" ]]; then
+    info "Creating Python virtual environment"
+    python3 -m venv "$VENV_DIR"
+else
+    info "Python virtual environment already exists"
+fi
+
+source "$VENV_DIR/bin/activate"
+trap 'deactivate >/dev/null 2>&1 || true' EXIT
+
+info "Upgrading pip and wheel"
+pip install --upgrade pip wheel
+
+info "Installing Python dependencies"
+pip install -r "$PROJECT_ROOT/server/requirements.txt"
+
+info "Installing Linux Whisper extras"
+pip install "faster-whisper>=1.0.0" "ctranslate2>=4.3"
+
+deactivate
+trap - EXIT
+
+info "Installing Node.js dependencies"
+(cd "$PROJECT_ROOT/client" && npm install)
+
+mkdir -p "$LOG_DIR"
+info "Downloading required KittenTTS models (logs: $LOG_DIR/model_download.log)"
+source "$VENV_DIR/bin/activate"
+python "$PROJECT_ROOT/server/download_kittentts_model.py" >>"$LOG_DIR/model_download.log" 2>&1 || \
+    warning "Model download encountered issues. Review $LOG_DIR/model_download.log"
+deactivate
+
+success "Linux setup complete. Start the stack with ./run_linux.sh"

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+set -euo pipefail
+
+OS_NAME="$(uname -s)"
+if [[ "$OS_NAME" != "Darwin" ]]; then
+    echo "[ERROR] setup_mac.sh must be run on macOS (Darwin). Detected: $OS_NAME" >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$SCRIPT_DIR"
+VENV_DIR="$PROJECT_ROOT/venv"
+LOG_DIR="$PROJECT_ROOT/logs"
+
+info() { echo "[INFO] $1"; }
+success() { echo "[SUCCESS] $1"; }
+warning() { echo "[WARNING] $1"; }
+error() { echo "[ERROR] $1" >&2; }
+
+require_command() {
+    local cmd="$1"
+    local install_hint="$2"
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        error "Missing required command: $cmd"
+        echo "$install_hint" >&2
+        exit 1
+    fi
+}
+
+ensure_brew_package() {
+    local package="$1"
+    if brew list "$package" >/dev/null 2>&1; then
+        info "brew package '$package' already installed"
+    else
+        info "Installing brew package '$package'"
+        brew install "$package"
+    fi
+}
+
+info "Detected macOS. Preparing environment in $PROJECT_ROOT"
+
+require_command "brew" "Install Homebrew from https://brew.sh before running this script."
+require_command "python3" "Install Python 3 (3.11 or newer) via Homebrew: brew install python@3.11"
+require_command "npm" "Install Node.js 18+: brew install node"
+
+BREW_PACKAGES=(ffmpeg sox portaudio)
+for pkg in "${BREW_PACKAGES[@]}"; do
+    ensure_brew_package "$pkg"
+done
+
+if [[ ! -d "$VENV_DIR" ]]; then
+    info "Creating Python virtual environment"
+    python3 -m venv "$VENV_DIR"
+else
+    info "Python virtual environment already exists"
+fi
+
+source "$VENV_DIR/bin/activate"
+trap 'deactivate >/dev/null 2>&1 || true' EXIT
+
+info "Upgrading pip and wheel"
+pip install --upgrade pip wheel
+
+info "Installing Python dependencies"
+pip install -r "$PROJECT_ROOT/server/requirements.txt"
+
+info "Installing macOS MLX extras"
+pip install "mlx>=0.25.0" "mlx-lm>=0.19.0,<0.24.0" mlx-audio==0.2.0
+
+deactivate
+trap - EXIT
+
+info "Installing Node.js dependencies"
+(cd "$PROJECT_ROOT/client" && npm install)
+
+mkdir -p "$LOG_DIR"
+info "Downloading required KittenTTS models (logs: $LOG_DIR/model_download.log)"
+source "$VENV_DIR/bin/activate"
+python "$PROJECT_ROOT/server/download_kittentts_model.py" >>"$LOG_DIR/model_download.log" 2>&1 || \
+    warning "Model download encountered issues. Review $LOG_DIR/model_download.log"
+deactivate
+
+success "macOS setup complete. Start the stack with ./run_mac.sh"

--- a/task.md
+++ b/task.md
@@ -14,3 +14,7 @@
 - [x] Emit canonical structured logs with derived skepticism line from the Flutter bridge.
 - [x] Support injectable HTTP clients and robust remote fallback handling in `LlamaBridge`.
 - [x] Expand Flutter unit coverage for remote token streaming and HTTP error surfacing.
+
+## Platform Scripts
+- [x] Provide dedicated macOS setup/run scripts.
+- [x] Provide dedicated Linux setup/run scripts.


### PR DESCRIPTION
## Summary
- add dedicated macOS setup script that installs dependencies, prepares the venv, and downloads KittenTTS models
- add Linux setup script with package manager guidance plus reusable run entrypoints for both platforms
- document the new scripts in the README and mark the platform task checklist as complete

## Testing
- `cd server && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68eaf77fe020832ba5ed0a945688d434